### PR TITLE
Fix translation of row-count in browse and search pages

### DIFF
--- a/view/common/pagination.phtml
+++ b/view/common/pagination.phtml
@@ -27,7 +27,7 @@ $translate = $this->plugin('translate');
     $from = $offset + 1;
     $to = ($currentPage < $pageCount) ? $offset + $perPage : $totalCount;
     ?>
-    <span class="row-count"><?php echo sprintf($translate('%s–%s of %s'), $from, $to, $totalCount); ?></span>
+    <span class="row-count"><?php echo sprintf($translate('%1$s–%2$s of %3$s'), $from, $to, $totalCount); ?></span>
 <?php else: ?>
     <?php echo $translate('0 results'); ?>
 <?php endif; ?>


### PR DESCRIPTION
This is in line with what is currently in Omeka S 2.1.2 and Omeka S 3 alpha. Otherwise, this string is not translated