### PR TITLE
Rename and translate the Tools button

### DIFF
--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -19,14 +19,14 @@ $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse')
 
 <?php echo $this->searchFilters(); ?>
 <div class="browse-control-mobile">
-<button type="button" class="browse-toggle closed">Tools</button>
+<button type="button" class="browse-toggle closed"><?php echo $translate('Options'); ?></button>
 </div>
 <div class="browse-controls closed">
     <?php echo $this->pagination(); ?>
     <?php if (strpos($layoutSetting, 'toggle') !== false): ?>
     <div class="layout-toggle">
         <button type="button" aria-label="<?php echo $translate('Grid'); ?>" class="grid o-icon-grid" <?php echo $gridState; ?>></button>
-        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>        
+        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>
     </div>
     <?php endif; ?>
 </div>

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -53,14 +53,14 @@ $sortHeadings = [
 
 <?php echo $this->searchFilters(); ?>
 <div class="browse-control-mobile">
-<button type="button" class="browse-toggle closed">Tools</button>
+<button type="button" class="browse-toggle closed"><?php echo $translate('Options'); ?></button>
 </div>
 <div class="browse-controls closed">
     <?php echo $this->pagination(); ?>
     <?php if (strpos($layoutSetting, 'toggle') !== false): ?>
     <div class="layout-toggle">
         <button type="button" aria-label="<?php echo $translate('Grid'); ?>" class="grid o-icon-grid" <?php echo $gridState; ?>></button>
-        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>        
+        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>
     </div>
     <?php endif; ?>
     <?php echo $this->hyperlink($translate('Advanced search'), $this->url('site/resource', ['controller' => 'item', 'action' => 'search'], ['query' => $query], true), ['class' => 'advanced-search']); ?>
@@ -73,7 +73,7 @@ $sortHeadings = [
 foreach ($items as $item):
     $heading = $headingTerm ? $item->value($headingTerm, ['default' => $translate('[Untitled]')]) : $item->displayTitle();
     $body = $bodyTerm ? $item->value($bodyTerm) : $item->displayDescription();
-?>  
+?>
     <li class="item resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($item, 'medium')): ?>
         <div class="resource-image <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">


### PR DESCRIPTION
Hello,

In #16 I noticed that the 'Tools' button label was not translated. Actually, there is no translation for this term on Omeka S core Transifex repository either, so adding $translate(...) does not help much (maybe that was why it's untranslated?).
In this PR I'm suggesting this button to be labled 'Options', and properly translated.

Best regards

Laurent