### PR TITLE
Site localization: filter values based on language

### DIFF
--- a/config/theme.ini
+++ b/config/theme.ini
@@ -75,3 +75,17 @@ elements.truncate_body_property.info = "How to handle long values for the body p
 elements.truncate_body_property.options.value_options.full = "Show full value"
 elements.truncate_body_property.options.value_options.fadeout = "Show 4 lines and fade out"
 elements.truncate_body_property.options.value_options.ellipsis = "Show 4 lines and clip with an ellipsis"
+
+elements.filter_locale_values.name = "filter_locale_values"
+elements.filter_locale_values.attributes.id = "filter_locale_values"
+elements.filter_locale_values.type = "Checkbox"
+elements.filter_locale_values.options.label = "Filter values based on site localization"
+elements.filter_locale_values.options.info = "Check to show only values matching the site language setting and values without locale ID."
+elements.filter_locale_values.attributes.value = 0
+
+elements.show_locale_label.name = "show_locale_label"
+elements.show_locale_label.attributes.id = "show_locale_label"
+elements.show_locale_label.type = "Checkbox"
+elements.show_locale_label.options.label = "Show values locale labels"
+elements.show_locale_label.options.info = "Check to show locale labels in front of properties values when applicable. Leave unchecked to hide those labels."
+elements.show_locale_label.attributes.value = 0

--- a/view/common/block-layout/browse-preview.phtml
+++ b/view/common/block-layout/browse-preview.phtml
@@ -43,29 +43,44 @@ $lang = $this->lang();
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($this->resources as $resource):
-$heading = $headingTerm ? $resource->value($headingTerm, ['default' => $translate('[Untitled]')]) : $resource->displayTitle();
-
-$body = null;
-if ($bodyTerm) {
-    $bodyTermValue = $resource->value($bodyTerm);
-    $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-    $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-} else {
-    // Based on resource template
-    $template = $resource->resourceTemplate();
-    if ($template && $template->descriptionProperty()) {
-        if (($filterLocale == 0) || !($bodyTermValue = $resource->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
-            $bodyTermValue = $resource->value($template->descriptionProperty()->term());
+    $heading = null;
+    if ($headingTerm) {
+        if (!($heading = $resource->value($headingTerm, ['lang' => $lang]))) {
+            $heading = $resource->value($headingTerm, ['default' => $translate('[Untitled]')]);
         }
-        if (null !== $bodyTermValue) {
-            $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-            $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+    } else {
+        $template = $resource->resourceTemplate();
+        if ($template && $template->titleProperty()) {
+            if (($filterLocale == 0) || !($heading = $resource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                $heading = $resource->value($template->titleProperty()->term());
+            }
         }
     }
-}
-if (!$body) {
-    $body = $resource->displayDescription();
-}
+    if (!$heading) {
+        $heading = $resource->displayTitle();
+    }
+
+    $body = null;
+    if ($bodyTerm) {
+        $bodyTermValue = $resource->value($bodyTerm);
+        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+    } else {
+        // Based on resource template
+        $template = $resource->resourceTemplate();
+        if ($template && $template->descriptionProperty()) {
+            if (($filterLocale == 0) || !($bodyTermValue = $resource->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+                $bodyTermValue = $resource->value($template->descriptionProperty()->term());
+            }
+            if (null !== $bodyTermValue) {
+                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+            }
+        }
+    }
+    if (!$body) {
+        $body = $resource->displayDescription();
+    }
 ?>
     <li class="<?php echo $this->resourceType; ?> resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($resource, 'medium')): ?>

--- a/view/common/block-layout/browse-preview.phtml
+++ b/view/common/block-layout/browse-preview.phtml
@@ -11,11 +11,7 @@ $queryUrl = $this->url(
     'site/resource', ['controller' => $this->resourceType, 'action' => 'browse'], ['query' => $this->query], true
 );
 
-$headingTerm = $this->siteSetting('browse_heading_property_term');
 $bodyTerm = $this->siteSetting('browse_body_property_term');
-
-$filterLocale = $this->themeSetting('filter_locale_values');
-$lang = $this->lang();
 ?>
 <div class="preview-block">
 
@@ -43,44 +39,7 @@ $lang = $this->lang();
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($this->resources as $resource):
-    $heading = null;
-    if ($headingTerm) {
-        if (!($heading = $resource->value($headingTerm, ['lang' => $lang]))) {
-            $heading = $resource->value($headingTerm, ['default' => $translate('[Untitled]')]);
-        }
-    } else {
-        $template = $resource->resourceTemplate();
-        if ($template && $template->titleProperty()) {
-            if (($filterLocale == 0) || !($heading = $resource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                $heading = $resource->value($template->titleProperty()->term());
-            }
-        }
-    }
-    if (!$heading) {
-        $heading = $resource->displayTitle();
-    }
-
-    $body = null;
-    if ($bodyTerm) {
-        $bodyTermValue = $resource->value($bodyTerm);
-        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-    } else {
-        // Based on resource template
-        $template = $resource->resourceTemplate();
-        if ($template && $template->descriptionProperty()) {
-            if (($filterLocale == 0) || !($bodyTermValue = $resource->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
-                $bodyTermValue = $resource->value($template->descriptionProperty()->term());
-            }
-            if (null !== $bodyTermValue) {
-                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-            }
-        }
-    }
-    if (!$body) {
-        $body = $resource->displayDescription();
-    }
+    $body = $bodyTerm ? $resource->value($bodyTerm) : $resource->displayDescription();
 ?>
     <li class="<?php echo $this->resourceType; ?> resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($resource, 'medium')): ?>
@@ -89,9 +48,9 @@ foreach ($this->resources as $resource):
         </div>
         <?php endif; ?>
         <div class="resource-meta <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">
-            <h4><?php echo $resource->link($heading); ?></h4>
+            <h4><?php echo $this->partial('common/local-title', ['resource' => $resource, 'method' => 'link']); ?></h4>
             <?php if ($body): ?>
-            <div class="description"><?php echo $escape($body); ?></div>
+            <div class="description"><?php echo $this->partial('common/local-body', ['resource' => $resource]); ?></div>
             <?php endif; ?>
         </div>
     </li>

--- a/view/common/block-layout/browse-preview.phtml
+++ b/view/common/block-layout/browse-preview.phtml
@@ -10,6 +10,12 @@ $isGrid = ($currentLayout == 'grid') ? true : false;
 $queryUrl = $this->url(
     'site/resource', ['controller' => $this->resourceType, 'action' => 'browse'], ['query' => $this->query], true
 );
+
+$headingTerm = $this->siteSetting('browse_heading_property_term');
+$bodyTerm = $this->siteSetting('browse_body_property_term');
+
+$filterLocale = $this->themeSetting('filter_locale_values');
+$lang = $this->lang();
 ?>
 <div class="preview-block">
 
@@ -28,7 +34,7 @@ $queryUrl = $this->url(
 <div class="browse-controls">
     <div class="layout-toggle">
         <button type="button" aria-label="<?php echo $translate('Grid'); ?>" class="grid o-icon-grid" <?php echo $gridState; ?>></button>
-        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>        
+        <button type="button" aria-label="<?php echo $translate('List'); ?>" class="list o-icon-list" <?php echo $listState; ?>></button>
     </div>
 </div>
 <?php endif; ?>
@@ -36,11 +42,30 @@ $queryUrl = $this->url(
 
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
-$headingTerm = $this->siteSetting('browse_heading_property_term');
-$bodyTerm = $this->siteSetting('browse_body_property_term');
 foreach ($this->resources as $resource):
-    $heading = $headingTerm ? $resource->value($headingTerm, ['default' => $translate('[Untitled]')]) : $resource->displayTitle();
-    $body = $bodyTerm ? $resource->value($bodyTerm) : $resource->displayDescription();
+$heading = $headingTerm ? $resource->value($headingTerm, ['default' => $translate('[Untitled]')]) : $resource->displayTitle();
+
+$body = null;
+if ($bodyTerm) {
+    $bodyTermValue = $resource->value($bodyTerm);
+    $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+    $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+} else {
+    // Based on resource template
+    $template = $resource->resourceTemplate();
+    if ($template && $template->descriptionProperty()) {
+        if (($filterLocale == 0) || !($bodyTermValue = $resource->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+            $bodyTermValue = $resource->value($template->descriptionProperty()->term());
+        }
+        if (null !== $bodyTermValue) {
+            $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+            $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+        }
+    }
+}
+if (!$body) {
+    $body = $resource->displayDescription();
+}
 ?>
     <li class="<?php echo $this->resourceType; ?> resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($resource, 'medium')): ?>

--- a/view/common/local-body.phtml
+++ b/view/common/local-body.phtml
@@ -1,0 +1,61 @@
+<?php 
+$translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+
+$bodyTerm = $this->siteSetting('browse_body_property_term');
+$headingTerm = $this->siteSetting('browse_heading_property_term');
+$filterLocale = $this->themeSetting('filter_locale_values');
+$lang = $this->lang();
+
+$method = isset($method) ? $method : "echo";
+
+
+if (isset($resource)) {
+    $body = null;
+    if ($bodyTerm) {
+        $bodyTermValue = $resource->value($bodyTerm);
+        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+    } else {
+        // Based on resource template
+        $template = $resource->resourceTemplate();
+        if ($template && $template->descriptionProperty()) {
+            if (($filterLocale == 0) || !($bodyTermValue = $resource->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+                $bodyTermValue = $resource->value($template->descriptionProperty()->term());
+            }
+            if (null !== $bodyTermValue) {
+                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+                if ($bodyTermValue && $bodyResource) {
+                    if ($headingTerm) {
+                        if (! ($body = $bodyResource->value($headingTerm, ['lang' => $lang]))) {
+                            $body = $bodyResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
+                        }
+                    } else {
+                        $template = $bodyResource->resourceTemplate();
+                        if ($template && $template->titleProperty()) {
+                            if (($filterLocale == 0)
+                                || ! ($body = $bodyResource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                                    $body = $bodyResource->value($template->titleProperty()->term());
+                                }
+                        }
+                    }
+                    if (!$body) {
+                        $body = $bodyResource->displayTitle();
+                    }
+                } else {
+                    $body = $bodyTermValue;
+                }
+            }
+        }
+    }
+    if (!$body) {
+        $body = $item->displayDescription();
+    }
+    
+    switch ($method) {
+        case "echo":
+        default:
+            echo $escape($body);
+    }
+}
+?>

--- a/view/common/local-body.phtml
+++ b/view/common/local-body.phtml
@@ -49,7 +49,7 @@ if (isset($resource)) {
         }
     }
     if (!$body) {
-        $body = $item->displayDescription();
+        $body = $resource->displayDescription();
     }
     
     switch ($method) {

--- a/view/common/local-title.phtml
+++ b/view/common/local-title.phtml
@@ -1,0 +1,51 @@
+<?php 
+$translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+
+$headingTerm = $this->siteSetting('browse_heading_property_term');
+$filterLocale = $this->themeSetting('filter_locale_values');
+$lang = $this->lang();
+
+$method = isset($method) ? $method : "echo";
+
+if (isset($resource)) {
+    $title = null;
+    if ($headingTerm) {
+        if (!($title = $resource->value($headingTerm, ['lang' => $lang]))) {
+            $title = $resource->value($headingTerm, ['default' => $translate('[Untitled]')]);
+        }
+    } else {
+        $template = $resource->resourceTemplate();
+        if ($template && $template->titleProperty()) {
+            if (($filterLocale == 0) || !($title = $resource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                $title = $resource->value($template->titleProperty()->term());
+            }
+        }
+    }
+    if (!$title) {
+        $title = $resource->displayTitle();
+    }
+    
+    switch ($method) {
+        case "pageTitle":
+            echo $this->pageTitle($title, $level);
+            break;
+            
+        case "link":
+            echo $resource->link($title);
+            break;
+            
+        case "linkRaw":
+            $linkContent = $this->thumbnail($resource, 'square')
+            . '<span class="resource-name">'
+                . $escape($title)
+                . "</span>";
+            echo $resource->linkRaw($linkContent, null, ['class' => 'resource-link']);
+            break;
+            
+        case "echo":
+        default:
+            echo $escape($title);
+    }
+}
+?>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -38,7 +38,7 @@ $siteLang = $this->lang();
             }
             ?>
             <?php if (($filterLocale == 0) || ($valueLang == '') || ($valueLang == $siteLang)): ?>
-            <dl class="<?php echo implode(' ', $class); ?>" lang="<?php echo $escape($value->lang()); ?>">
+            <dl class="<?php echo implode(' ', $class); ?>" lang="<?php echo $escape($valueLang); ?>">
                 <?php if (($showLocale == 1) && ($valueLang)): ?>
                 <span class="language"><?php echo $valueLang; ?></span>
                 <?php endif; ?>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -5,7 +5,6 @@ $labelInfo = $this->setting('property_label_information');
 $filterLocale = $this->themeSetting('filter_locale_values');
 $showLocale = $this->themeSetting('show_locale_label');
 $lang = $this->lang();
-$headingTerm = $this->siteSetting('browse_heading_property_term');
 ?>
 <dl>
 <?php foreach ($values as $term => $propertyData): ?>
@@ -45,28 +44,7 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
                 <?php endif; ?>
                 <?php if ($linkedResource = $value->valueResource()):?>
                 <?php
-                    $linkedResourceTitle = null;
-                    if ($headingTerm) {
-                        if (! ($linkedResourceTitle = $linkedResource->value($headingTerm, ['lang' => $lang]))) {
-                            $linkedResourceTitle = $linkedResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
-                        }
-                    } else {
-                        $template = $linkedResource->resourceTemplate();
-                        if ($template && $template->titleProperty()) {
-                            if (($filterLocale == 0)
-                                || ! ($linkedResourceTitle = $linkedResource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                                $linkedResourceTitle = $linkedResource->value($template->titleProperty()->term());
-                            }
-                        }
-                    }
-                    if (! $linkedResourceTitle) {
-                        $linkedResourceTitle = $linkedResource->displayTitle();
-                    }
-                    $linkContent = $this->thumbnail($value->valueResource(), 'square')
-                                    . '<span class="resource-name">'
-                                    . $escape($linkedResourceTitle)
-                                    . "</span>";
-                    echo $value->valueResource()->linkRaw($linkContent, null, ['class' => 'resource-link']);
+                echo $this->partial('common/local-title', ['resource' => $linkedResource, 'method' => 'linkRaw']);
                  ?>
                  <?php else: ?>
                  <?php echo $value->asHtml(); ?>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -4,7 +4,8 @@ $escape = $this->plugin('escapeHtml');
 $labelInfo = $this->setting('property_label_information');
 $filterLocale = $this->themeSetting('filter_locale_values');
 $showLocale = $this->themeSetting('show_locale_label');
-$siteLang = $this->lang();
+$lang = $this->lang();
+$headingTerm = $this->siteSetting('browse_heading_property_term');
 ?>
 <dl>
 <?php foreach ($values as $term => $propertyData): ?>
@@ -37,12 +38,49 @@ $siteLang = $this->lang();
                 $class[] = 'private';
             }
             ?>
-            <?php if (($filterLocale == 0) || ($valueLang == '') || ($valueLang == $siteLang)): ?>
+            <?php if (($filterLocale == 0) || ($valueLang == '') || ($valueLang == $lang)): ?>
             <dl class="<?php echo implode(' ', $class); ?>" lang="<?php echo $escape($valueLang); ?>">
                 <?php if (($showLocale == 1) && ($valueLang)): ?>
                 <span class="language"><?php echo $valueLang; ?></span>
                 <?php endif; ?>
-                <?php echo $value->asHtml(); ?>
+
+				<?php if ($linkedResource = $value->valueResource()):?>
+					<?php
+
+                    $linkedResourceTitle = null;
+
+                    if ($headingTerm) {
+                        if (! ($linkedResourceTitle = $linkedResource->value($headingTerm, [
+                            'lang' => $lang
+                        ]))) {
+                            $linkedResourceTitle = $linkedResource->value($headingTerm, [
+                                'default' => $translate('[Untitled]')
+                            ]);
+                        }
+                    } else {
+                        $template = $linkedResource->resourceTemplate();
+                        if ($template && $template->titleProperty()) {
+                            if (($filterLocale == 0) || ! ($linkedResourceTitle = $linkedResource->value($template->titleProperty()
+                                ->term(), [
+                                'lang' => $lang
+                            ]))) {
+                                $linkedResourceTitle = $linkedResource->value($template->titleProperty()
+                                    ->term());
+                            }
+                        }
+                    }
+                    if (! $linkedResourceTitle) {
+                        $linkedResourceTitle = $linkedResource->displayTitle();
+                    }
+
+                    $linkContent = $this->thumbnail($value->valueResource(), 'square') . '<span class="resource-name">' . $escape($linkedResourceTitle) . "</span>";
+                    echo $value->valueResource()->linkRaw($linkContent, null, [
+                        'class' => 'resource-link'
+                    ]);
+                    ?>
+				<?php else: ?>
+					<?php echo $value->asHtml(); ?>
+                <?php endif;?>
             </dl>
             <?php endif; ?>
         <?php endforeach; ?>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -2,6 +2,9 @@
 $translate = $this->plugin('translate');
 $escape = $this->plugin('escapeHtml');
 $labelInfo = $this->setting('property_label_information');
+$filterLocale = $this->themeSetting('filter_locale_values');
+$showLocale = $this->themeSetting('show_locale_label');
+$siteLang = $this->lang();
 ?>
 <dl>
 <?php foreach ($values as $term => $propertyData): ?>
@@ -22,6 +25,7 @@ $labelInfo = $this->setting('property_label_information');
         <?php foreach ($propertyData['values'] as $value): ?>
             <?php
             $valueType = $value->type();
+            $valueLang = $value->lang();
             $class = ['value'];
             if ('resource' == $valueType || strpos($valueType, 'resource') !== false) {
                 $class[] = 'resource';
@@ -33,12 +37,14 @@ $labelInfo = $this->setting('property_label_information');
                 $class[] = 'private';
             }
             ?>
+            <?php if (($filterLocale == 0) || ($valueLang == '') || ($valueLang == $siteLang)): ?>
             <dl class="<?php echo implode(' ', $class); ?>" lang="<?php echo $escape($value->lang()); ?>">
-                <?php if ($language = $value->lang()): ?>
-                <span class="language"><?php echo $language; ?></span>
+                <?php if (($showLocale == 1) && ($valueLang)): ?>
+                <span class="language"><?php echo $valueLang; ?></span>
                 <?php endif; ?>
                 <?php echo $value->asHtml(); ?>
             </dl>
+            <?php endif; ?>
         <?php endforeach; ?>
         </div>
     </div>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -43,12 +43,9 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
                 <?php if (($showLocale == 1) && ($valueLang)): ?>
                 <span class="language"><?php echo $valueLang; ?></span>
                 <?php endif; ?>
-
-				<?php if ($linkedResource = $value->valueResource()):?>
-					<?php
-
+                <?php if ($linkedResource = $value->valueResource()):?>
+                <?php
                     $linkedResourceTitle = null;
-
                     if ($headingTerm) {
                         if (! ($linkedResourceTitle = $linkedResource->value($headingTerm, ['lang' => $lang]))) {
                             $linkedResourceTitle = $linkedResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
@@ -65,18 +62,15 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
                     if (! $linkedResourceTitle) {
                         $linkedResourceTitle = $linkedResource->displayTitle();
                     }
-
                     $linkContent = $this->thumbnail($value->valueResource(), 'square')
                                     . '<span class="resource-name">'
                                     . $escape($linkedResourceTitle)
                                     . "</span>";
-                    echo $value->valueResource()->linkRaw($linkContent, null, [
-                        'class' => 'resource-link'
-                    ]);
-                    ?>
-				<?php else: ?>
-					<?php echo $value->asHtml(); ?>
-                <?php endif;?>
+                    echo $value->valueResource()->linkRaw($linkContent, null, ['class' => 'resource-link']);
+                 ?>
+                 <?php else: ?>
+                 <?php echo $value->asHtml(); ?>
+                 <?php endif;?>
             </dl>
             <?php endif; ?>
         <?php endforeach; ?>

--- a/view/common/resource-values.phtml
+++ b/view/common/resource-values.phtml
@@ -50,22 +50,15 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
                     $linkedResourceTitle = null;
 
                     if ($headingTerm) {
-                        if (! ($linkedResourceTitle = $linkedResource->value($headingTerm, [
-                            'lang' => $lang
-                        ]))) {
-                            $linkedResourceTitle = $linkedResource->value($headingTerm, [
-                                'default' => $translate('[Untitled]')
-                            ]);
+                        if (! ($linkedResourceTitle = $linkedResource->value($headingTerm, ['lang' => $lang]))) {
+                            $linkedResourceTitle = $linkedResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
                         }
                     } else {
                         $template = $linkedResource->resourceTemplate();
                         if ($template && $template->titleProperty()) {
-                            if (($filterLocale == 0) || ! ($linkedResourceTitle = $linkedResource->value($template->titleProperty()
-                                ->term(), [
-                                'lang' => $lang
-                            ]))) {
-                                $linkedResourceTitle = $linkedResource->value($template->titleProperty()
-                                    ->term());
+                            if (($filterLocale == 0)
+                                || ! ($linkedResourceTitle = $linkedResource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                                $linkedResourceTitle = $linkedResource->value($template->titleProperty()->term());
                             }
                         }
                     }
@@ -73,7 +66,10 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
                         $linkedResourceTitle = $linkedResource->displayTitle();
                     }
 
-                    $linkContent = $this->thumbnail($value->valueResource(), 'square') . '<span class="resource-name">' . $escape($linkedResourceTitle) . "</span>";
+                    $linkContent = $this->thumbnail($value->valueResource(), 'square')
+                                    . '<span class="resource-name">'
+                                    . $escape($linkedResourceTitle)
+                                    . "</span>";
                     echo $value->valueResource()->linkRaw($linkContent, null, [
                         'class' => 'resource-link'
                     ]);

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -6,14 +6,10 @@ $layoutSetting = $this->themeSetting('browse_layout');
 $gridState = ($layoutSetting == 'togglegrid') ? 'disabled' : '';
 $listState = ($layoutSetting == 'togglelist') ? 'disabled': '';
 $isGrid = (!isset($layoutSetting) || strpos($layoutSetting, 'grid') !== false) ? true : false;
-$headingTerm = $this->siteSetting('browse_heading_property_term');
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 
 $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse');
-
-$filterLocale = $this->themeSetting('filter_locale_values');
-$lang = $this->lang();
 ?>
 
 <?php echo $this->pageTitle($translate('Item sets'), 2); ?>
@@ -38,45 +34,7 @@ $lang = $this->lang();
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($itemSets as $itemSet):
-
-    $heading = null;
-    if ($headingTerm) {
-        if (!($heading = $itemSet->value($headingTerm, ['lang' => $lang]))) {
-            $heading = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
-        }
-    } else {
-        $template = $itemSet->resourceTemplate();
-        if ($template && $template->titleProperty()) {
-            if (($filterLocale == 0) || !($heading = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                $heading = $itemSet->value($template->titleProperty()->term());
-            }
-        }
-    }
-    if (!$heading) {
-        $heading = $itemSet->displayTitle();
-    }
-
-    $body = null;
-    if ($bodyTerm) {
-        $bodyTermValue = $itemSet->value($bodyTerm);
-        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-    } else {
-        // Based on resource template
-        $template = $itemSet->resourceTemplate();
-        if ($template && $template->descriptionProperty()) {
-            if (($filterLocale == 0) || !($bodyTermValue = $itemSet->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
-                $bodyTermValue = $itemSet->value($template->descriptionProperty()->term());
-            }
-            if (null !== $bodyTermValue) {
-                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-            }
-        }
-    }
-    if (!$body) {
-        $body = $itemSet->displayDescription();
-    }
+    $body = $bodyTerm ? $itemSet->value($bodyTerm) : $itemSet->displayDescription();
 ?>
     <li class="item-set resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($itemSet, 'medium')): ?>
@@ -85,9 +43,9 @@ foreach ($itemSets as $itemSet):
         </div>
         <?php endif; ?>
         <div class="resource-meta <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">
-            <h4><?php echo $itemSet->link($heading); ?></h4>
+            <h4><?php echo $this->partial('common/local-title', ['resource' => $itemSet, 'method' => 'link']); ?></h4>
             <?php if ($body): ?>
-            <div class="description <?php echo ($bodyTruncate) ? $bodyTruncate : ''; ?>"><?php echo $escape($body); ?></div>
+            <div class="description <?php echo ($bodyTruncate) ? $bodyTruncate : ''; ?>"><?php echo $this->partial('common/local-body', ['resource' => $itemSet]); ?></div>
             <?php endif; ?>
         </div>
     </li>

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -44,7 +44,28 @@ foreach ($itemSets as $itemSet):
     } else {
         $heading = $itemSet->displayTitle();
     }
-    $body = $bodyTerm ? $itemSet->value($bodyTerm) : $itemSet->displayDescription();
+
+    $body = null;
+    if ($bodyTerm) {
+        $bodyTermValue = $itemSet->value($bodyTerm);
+        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+    } else {
+        // Based on resource template
+        $template = $itemSet->resourceTemplate();
+        if ($template && $template->descriptionProperty()) {
+            if (!($bodyTermValue = $itemSet->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+                $bodyTermValue = $itemSet->value($template->descriptionProperty()->term());
+            }
+            if (null !== $bodyTermValue) {
+                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+            }
+        }
+    }
+    if (!$body) {
+        $body = $itemSet->displayDescription();
+    }
 ?>
     <li class="item-set resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($itemSet, 'medium')): ?>

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -39,11 +39,20 @@ $lang = $this->lang();
 <?php
 foreach ($itemSets as $itemSet):
 
+    $heading = null;
     if ($headingTerm) {
         if (!($heading = $itemSet->value($headingTerm, ['lang' => $lang]))) {
             $heading = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
         }
     } else {
+        $template = $itemSet->resourceTemplate();
+        if ($template && $template->titleProperty()) {
+            if (($filterLocale == 0) || !($heading = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                $heading = $itemSet->value($template->titleProperty()->term());
+            }
+        }
+    }
+    if (!$heading) {
         $heading = $itemSet->displayTitle();
     }
 

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -11,6 +11,8 @@ $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 
 $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse');
+
+$filterLocale = $this->themeSetting('filter_locale_values');
 $lang = $this->lang();
 ?>
 
@@ -54,7 +56,7 @@ foreach ($itemSets as $itemSet):
         // Based on resource template
         $template = $itemSet->resourceTemplate();
         if ($template && $template->descriptionProperty()) {
-            if (!($bodyTermValue = $itemSet->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+            if (($filterLocale == 0) || !($bodyTermValue = $itemSet->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
                 $bodyTermValue = $itemSet->value($template->descriptionProperty()->term());
             }
             if (null !== $bodyTermValue) {

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -11,6 +11,7 @@ $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 
 $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse');
+$lang = $this->lang();
 ?>
 
 <?php echo $this->pageTitle($translate('Item sets'), 2); ?>
@@ -35,7 +36,14 @@ $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse')
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($itemSets as $itemSet):
-    $heading = $headingTerm ? $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]) : $itemSet->displayTitle();
+
+    if ($headingTerm) {
+        if (!($heading = $itemSet->value($headingTerm, ['lang' => $lang]))) {
+            $heading = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
+        }
+    } else {
+        $heading = $itemSet->displayTitle();
+    }
     $body = $bodyTerm ? $itemSet->value($bodyTerm) : $itemSet->displayDescription();
 ?>
     <li class="item-set resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -37,10 +37,21 @@ $sortHeadings = [
         'value' => 'created'
     ],
 ];
+
+$lang = $this->lang();
 ?>
 
 <?php if ($itemSetShow): ?>
-    <?php echo $this->pageTitle($itemSet->displayTitle(), 2); ?>
+	<?php
+	if ($headingTerm) {
+	    if (!($itemSetTitle = $itemSet->value($headingTerm, ['lang' => $lang]))) {
+	        $itemSetTitle = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
+	    }
+	} else {
+	   $itemSetTitle = $itemSet->displayTitle();
+	}
+    echo $this->pageTitle($itemSetTitle, 2);
+    ?>
     <h3><?php echo $translate('Item set'); ?></h3>
     <div class="metadata">
         <?php echo $itemSet->displayValues(); ?>

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -122,7 +122,26 @@ foreach ($items as $item):
             }
             if (null !== $bodyTermValue) {
                 $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+                if ($bodyTermValue && $bodyResource) {
+                    if ($headingTerm) {
+                        if (! ($body = $bodyResource->value($headingTerm, ['lang' => $lang]))) {
+                            $body = $bodyResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
+                        }
+                    } else {
+                        $template = $bodyResource->resourceTemplate();
+                        if ($template && $template->titleProperty()) {
+                            if (($filterLocale == 0)
+                                || ! ($body = $bodyResource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                                    $body = $bodyResource->value($template->titleProperty()->term());
+                                }
+                        }
+                    }
+                    if (!$body) {
+                        $body = $bodyResource->displayTitle();
+                    }
+                } else {
+                    $body = $bodyTermValue;
+                }
             }
         }
     }

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -38,6 +38,7 @@ $sortHeadings = [
     ],
 ];
 
+$filterLocale = $this->themeSetting('filter_locale_values');
 $lang = $this->lang();
 ?>
 
@@ -93,7 +94,7 @@ foreach ($items as $item):
         // Based on resource template
         $template = $item->resourceTemplate();
         if ($template && $template->descriptionProperty()) {
-            if (!($bodyTermValue = $item->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+            if (($filterLocale == 0) || !($bodyTermValue = $item->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
                 $bodyTermValue = $item->value($template->descriptionProperty()->term());
             }
             if (null !== $bodyTermValue) {

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -49,7 +49,15 @@ $lang = $this->lang();
 	        $itemSetTitle = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
 	    }
 	} else {
-	   $itemSetTitle = $itemSet->displayTitle();
+	    $template = $itemSet->resourceTemplate();
+	    if ($template && $template->titleProperty()) {
+	        if (($filterLocale == 0) || !($itemSetTitle = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+	            $itemSetTitle = $itemSet->value($template->titleProperty()->term());
+	        }
+	    }
+	}
+	if (!$itemSetTitle) {
+	    $itemSetTitle = $itemSet->displayTitle();
 	}
     echo $this->pageTitle($itemSetTitle, 2);
     ?>
@@ -83,7 +91,22 @@ $lang = $this->lang();
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($items as $item):
-    $heading = $headingTerm ? $item->value($headingTerm, ['default' => $translate('[Untitled]')]) : $item->displayTitle();
+    $heading = null;
+    if ($headingTerm) {
+        if (!($heading = $item->value($headingTerm, ['lang' => $lang]))) {
+            $heading = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
+        }
+    } else {
+        $template = $item->resourceTemplate();
+        if ($template && $template->titleProperty()) {
+            if (($filterLocale == 0) || !($heading = $item->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                $heading = $item->value($template->titleProperty()->term());
+            }
+        }
+    }
+    if (!$heading) {
+        $heading = $item->displayTitle();
+    }
 
     $body = null;
     if ($bodyTerm) {

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -44,22 +44,7 @@ $lang = $this->lang();
 
 <?php if ($itemSetShow): ?>
 	<?php
-	if ($headingTerm) {
-	    if (!($itemSetTitle = $itemSet->value($headingTerm, ['lang' => $lang]))) {
-	        $itemSetTitle = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
-	    }
-	} else {
-	    $template = $itemSet->resourceTemplate();
-	    if ($template && $template->titleProperty()) {
-	        if (($filterLocale == 0) || !($itemSetTitle = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-	            $itemSetTitle = $itemSet->value($template->titleProperty()->term());
-	        }
-	    }
-	}
-	if (!$itemSetTitle) {
-	    $itemSetTitle = $itemSet->displayTitle();
-	}
-    echo $this->pageTitle($itemSetTitle, 2);
+	echo $this->partial('common/local-title', ['resource' => $itemSet, 'method' => 'pageTitle', 'level' => 2]);
     ?>
     <h3><?php echo $translate('Item set'); ?></h3>
     <div class="metadata">
@@ -91,64 +76,7 @@ $lang = $this->lang();
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
 foreach ($items as $item):
-    $heading = null;
-    if ($headingTerm) {
-        if (!($heading = $item->value($headingTerm, ['lang' => $lang]))) {
-            $heading = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
-        }
-    } else {
-        $template = $item->resourceTemplate();
-        if ($template && $template->titleProperty()) {
-            if (($filterLocale == 0) || !($heading = $item->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                $heading = $item->value($template->titleProperty()->term());
-            }
-        }
-    }
-    if (!$heading) {
-        $heading = $item->displayTitle();
-    }
-
-    $body = null;
-    if ($bodyTerm) {
-        $bodyTermValue = $item->value($bodyTerm);
-        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
-    } else {
-        // Based on resource template
-        $template = $item->resourceTemplate();
-        if ($template && $template->descriptionProperty()) {
-            if (($filterLocale == 0) || !($bodyTermValue = $item->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
-                $bodyTermValue = $item->value($template->descriptionProperty()->term());
-            }
-            if (null !== $bodyTermValue) {
-                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
-                if ($bodyTermValue && $bodyResource) {
-                    if ($headingTerm) {
-                        if (! ($body = $bodyResource->value($headingTerm, ['lang' => $lang]))) {
-                            $body = $bodyResource->value($headingTerm, ['default' => $translate('[Untitled]')]);
-                        }
-                    } else {
-                        $template = $bodyResource->resourceTemplate();
-                        if ($template && $template->titleProperty()) {
-                            if (($filterLocale == 0)
-                                || ! ($body = $bodyResource->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                                    $body = $bodyResource->value($template->titleProperty()->term());
-                                }
-                        }
-                    }
-                    if (!$body) {
-                        $body = $bodyResource->displayTitle();
-                    }
-                } else {
-                    $body = $bodyTermValue;
-                }
-            }
-        }
-    }
-    if (!$body) {
-        $body = $item->displayDescription();
-    }
-
+    $body = $bodyTerm ? $item->value($bodyTerm) : $item->displayDescription();
 ?>
     <li class="item resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($item, 'medium')): ?>
@@ -157,9 +85,9 @@ foreach ($items as $item):
         </div>
         <?php endif; ?>
         <div class="resource-meta <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">
-            <h4><?php echo $item->link($heading); ?></h4>
+            <h4><?php echo $this->partial('common/local-title', ['resource' => $item, 'method' => 'link']); ?></h4>
             <?php if ($body): ?>
-            <div class="description <?php echo ($bodyTruncate) ? $bodyTruncate : ''; ?>"><?php echo $escape($body); ?></div>
+            <div class="description <?php echo ($bodyTruncate) ? $bodyTruncate : ''; ?>"><?php echo $this->partial('common/local-body', ['resource' => $item]); ?></div>
             <?php endif; ?>
         </div>
     </li>

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -83,7 +83,29 @@ $lang = $this->lang();
 <?php
 foreach ($items as $item):
     $heading = $headingTerm ? $item->value($headingTerm, ['default' => $translate('[Untitled]')]) : $item->displayTitle();
-    $body = $bodyTerm ? $item->value($bodyTerm) : $item->displayDescription();
+
+    $body = null;
+    if ($bodyTerm) {
+        $bodyTermValue = $item->value($bodyTerm);
+        $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+        $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+    } else {
+        // Based on resource template
+        $template = $item->resourceTemplate();
+        if ($template && $template->descriptionProperty()) {
+            if (!($bodyTermValue = $item->value($template->descriptionProperty()->term(), ['lang' => $lang]))) {
+                $bodyTermValue = $item->value($template->descriptionProperty()->term());
+            }
+            if (null !== $bodyTermValue) {
+                $bodyResource = $bodyTermValue ? $bodyTermValue->valueResource() : null;
+                $body = ($bodyTermValue && $bodyResource) ? $bodyResource->displayTitle() : $bodyTermValue;
+            }
+        }
+    }
+    if (!$body) {
+        $body = $item->displayDescription();
+    }
+
 ?>
     <li class="item resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
         <?php if ($thumbnail = $this->thumbnail($item, 'medium')): ?>

--- a/view/omeka/site/item/show.phtml
+++ b/view/omeka/site/item/show.phtml
@@ -68,7 +68,25 @@ endforeach;
         <dt><?php echo $translate('Item sets'); ?></dt>
         <div class="values">
             <?php foreach ($itemSets as $itemSet): ?>
-            <dd class="value"><a href="<?php echo $escape($itemSet->url()); ?>"><?php echo $itemSet->displayTitle(); ?></a></dd>
+            <?php
+            $itemSetTitle = null;
+            if ($headingTerm) {
+                if (!($itemSetTitle = $itemSet->value($headingTerm, ['lang' => $lang]))) {
+                    $itemSetTitle = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
+                }
+            } else {
+                $template = $itemSet->resourceTemplate();
+                if ($template && $template->titleProperty()) {
+                    if (($filterLocale == 0) || !($itemSetTitle = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+                        $itemSetTitle = $itemSet->value($template->titleProperty()->term());
+                    }
+                }
+            }
+            if (!$itemSetTitle) {
+                $itemSetTitle = $itemSet->displayTitle();
+            }
+            ?>
+            <dd class="value"><a href="<?php echo $escape($itemSet->url()); ?>"><?php echo $itemSetTitle; ?></a></dd>
             <?php endforeach; ?>
         </div>
     </div>

--- a/view/omeka/site/item/show.phtml
+++ b/view/omeka/site/item/show.phtml
@@ -5,10 +5,38 @@ $this->htmlElement('body')->appendAttribute('class', 'item resource show');
 $embedMedia = $this->siteSetting('item_media_embed', false);
 $itemMedia = $item->media();
 $showLayout = $this->themeSetting('show_layout');
+$headingTerm = $this->siteSetting('browse_heading_property_term');
+
+$filterLocale = $this->themeSetting('filter_locale_values');
+$lang = $this->lang();
+
+$this->headScript()->appendFile($this->assetUrl('js/lightslider.js'));
+$this->headLink()->prependStylesheet($this->assetUrl('css/lightslider.css'));
+$this->headScript()->appendFile($this->assetUrl('js/lightgallery.js'));
+$this->headScript()->appendFile($this->assetUrl('js/lg-zoom.js'));
+$this->headScript()->appendFile($this->assetUrl('js/lg-fullscreen.js'));
+$this->headLink()->prependStylesheet($this->assetUrl('css/lightgallery.css'));
 ?>
 
 <div class="resource-title">
-<?php echo $this->pageTitle($item->displayTitle(), 2); ?>
+<?php
+	if ($headingTerm) {
+	    if (!($itemTitle = $item->value($headingTerm, ['lang' => $lang]))) {
+	        $itemTitle = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
+	    }
+	} else {
+	    $template = $item->resourceTemplate();
+	    if ($template && $template->titleProperty()) {
+	        if (($filterLocale == 0) || !($itemTitle = $item->value($template->titleProperty()->term(), ['lang' => $lang]))) {
+	            $itemTitle = $item->value($template->titleProperty()->term());
+	        }
+	    }
+	}
+	if (!$itemTitle) {
+	    $itemTitle = $item->displayTitle();
+	}
+    echo $this->pageTitle($itemTitle, 2);
+?>
 <h3 class="label"><?php echo $translate('Item'); ?></h3>
 </div>
 

--- a/view/omeka/site/item/show.phtml
+++ b/view/omeka/site/item/show.phtml
@@ -5,10 +5,6 @@ $this->htmlElement('body')->appendAttribute('class', 'item resource show');
 $embedMedia = $this->siteSetting('item_media_embed', false);
 $itemMedia = $item->media();
 $showLayout = $this->themeSetting('show_layout');
-$headingTerm = $this->siteSetting('browse_heading_property_term');
-
-$filterLocale = $this->themeSetting('filter_locale_values');
-$lang = $this->lang();
 
 $this->headScript()->appendFile($this->assetUrl('js/lightslider.js'));
 $this->headLink()->prependStylesheet($this->assetUrl('css/lightslider.css'));
@@ -20,22 +16,7 @@ $this->headLink()->prependStylesheet($this->assetUrl('css/lightgallery.css'));
 
 <div class="resource-title">
 <?php
-	if ($headingTerm) {
-	    if (!($itemTitle = $item->value($headingTerm, ['lang' => $lang]))) {
-	        $itemTitle = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
-	    }
-	} else {
-	    $template = $item->resourceTemplate();
-	    if ($template && $template->titleProperty()) {
-	        if (($filterLocale == 0) || !($itemTitle = $item->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-	            $itemTitle = $item->value($template->titleProperty()->term());
-	        }
-	    }
-	}
-	if (!$itemTitle) {
-	    $itemTitle = $item->displayTitle();
-	}
-    echo $this->pageTitle($itemTitle, 2);
+    echo $this->partial('common/local-title', ['resource' => $item, 'method'=> 'pageTitle', 'level' => 2]);
 ?>
 <h3 class="label"><?php echo $translate('Item'); ?></h3>
 </div>
@@ -68,25 +49,7 @@ endforeach;
         <dt><?php echo $translate('Item sets'); ?></dt>
         <div class="values">
             <?php foreach ($itemSets as $itemSet): ?>
-            <?php
-            $itemSetTitle = null;
-            if ($headingTerm) {
-                if (!($itemSetTitle = $itemSet->value($headingTerm, ['lang' => $lang]))) {
-                    $itemSetTitle = $itemSet->value($headingTerm, ['default' => $translate('[Untitled]')]);
-                }
-            } else {
-                $template = $itemSet->resourceTemplate();
-                if ($template && $template->titleProperty()) {
-                    if (($filterLocale == 0) || !($itemSetTitle = $itemSet->value($template->titleProperty()->term(), ['lang' => $lang]))) {
-                        $itemSetTitle = $itemSet->value($template->titleProperty()->term());
-                    }
-                }
-            }
-            if (!$itemSetTitle) {
-                $itemSetTitle = $itemSet->displayTitle();
-            }
-            ?>
-            <dd class="value"><a href="<?php echo $escape($itemSet->url()); ?>"><?php echo $itemSetTitle; ?></a></dd>
+            <dd class="value"><a href="<?php echo $escape($itemSet->url()); ?>"><?php echo $this->partial('common/local-title', ['resource' => $itemSet]); ?></a></dd>
             <?php endforeach; ?>
         </div>
     </div>


### PR DESCRIPTION
Hello

This is a new feature submission that enables site localization by:
* hiding or showing values based on their language IETF tag
* retrieving resources' title and body in the adequate language based on site settings or resource template

Use case: Items store several language values for a same property and users want to create language specific sites.

Feature:
- Display items, property values, item sets, linked resources in the language as per the site settings
- New setting "Filter values based on site localization": global option to enable the feature. When checked, resources' property values will be shown only if their associated language IETF tag matches the site locale setting. Values without specified language will be shown in all cases, especially when language is not applicable (e.g.: serial numbers or IDs, etc.).
- New setting "Show values locale labels": this conditionally shows or hides the language label (useful when the previous setting is enabled and thus the label should be unique across the site).

You can have a look at the feature live on https://collection.manondamoon.com/s/en - a flag icon in the top bar is used to switch between sites with different languages.

Let me know if this feature is of interest.

Have a nice day
